### PR TITLE
fix: Escape displayed password with htmlSpecialChars

### DIFF
--- a/Resources/Private/Fusion/Helper/ProtectContent.fusion
+++ b/Resources/Private/Fusion/Helper/ProtectContent.fusion
@@ -22,7 +22,7 @@ prototype(CodeQ.PasswordProtectedContent:Helper.ProtectContent) < prototype(Neos
 			condition = ${renderContentInBackend && node.context.inBackend}
 			renderer = afx`
 				<Carbon.Notification:Tag type="info">
-					{Translation.translate('backend.configuredPasswordNotification', null, [configuredPassword], 'Fusion/Helper/ProtectContent', 'CodeQ.PasswordProtectedContent')}
+					{Translation.translate('backend.configuredPasswordNotification', null, [String.htmlSpecialChars(configuredPassword)], 'Fusion/Helper/ProtectContent', 'CodeQ.PasswordProtectedContent')}
 				</Carbon.Notification:Tag>
 				{content}
 			`

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["flow", "neos", "fusion", "password"],
     "require": {
-        "neos/neos": "~3.2 || ~4.0 || ~5.0 || ~7.0 || dev-master",
+        "neos/neos": "~3.2 || ~4.0 || ~5.0 || ~7.0  || ~8.0 || dev-master",
         "carbon/notification": "^1.0 || ^2.0 || dev-master"
     },
     "autoload": {


### PR DESCRIPTION
If an editor is using some special characters like `<` in their password, the backend can break.  Escaping the displayed password with `String.htmlSpecialChars()` will prevent this.

thanks for a quick merge @rolandschuetz 